### PR TITLE
修复 “obj.hasOwnProperty is not a function” 错误

### DIFF
--- a/src/internal/utils/utils.ts
+++ b/src/internal/utils/utils.ts
@@ -57,7 +57,7 @@ export class HttpUtils {
     }
 
     private static crossDomainRequest(info: RequestInfo): void {
-        if (window.hasOwnProperty('GM_xmlhttpRequest')) {
+        if (Object.hasOwnProperty.bind(window)('GM_xmlhttpRequest')) {
             //兼容油猴
             (<any>info).data = info.body;
             (<any>info).onreadystatechange = function (response: any) {


### PR DESCRIPTION
在 Firefox 环境下，自动答题时出现的问题。该错误导致无法向服务器发送查询题目数据包。